### PR TITLE
Feature/frame extraction

### DIFF
--- a/remora/build.gradle
+++ b/remora/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	runtimeOnly 'com.microsoft.sqlserver:mssql-jdbc'
 	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.jcodec:jcodec:0.2.5'
 }
 
 test {

--- a/remora/build.gradle
+++ b/remora/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.jcodec:jcodec:0.2.5'
+	implementation 'org.jcodec:jcodec-javase:0.2.5'
 }
 
 test {

--- a/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractinController.java
+++ b/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractinController.java
@@ -7,9 +7,9 @@ import remora.remora.FrameExtraction.dto.FrameExtractionResponseDto;
 
 @RestController
 public class FrameExtractinController {
-    FrameExtractionService frameExtractionService;
+    FrameExtractionService frameExtractionService = new FrameExtractionService();
 
-    public FrameExtractionResponseDto frameExtract(FrameExtractionRequestDto request) throws Exception {
+    public FrameExtractionResponseDto frameExtract(FrameExtractionRequestDto request) {
         return frameExtractionService.frameExtract(request);
     }
 }

--- a/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractinController.java
+++ b/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractinController.java
@@ -1,0 +1,15 @@
+package remora.remora.FrameExtraction;
+
+import org.springframework.web.bind.annotation.RestController;
+
+import remora.remora.FrameExtraction.dto.FrameExtractionRequestDto;
+import remora.remora.FrameExtraction.dto.FrameExtractionResponseDto;
+
+@RestController
+public class FrameExtractinController {
+    FrameExtractionService frameExtractionService;
+
+    public FrameExtractionResponseDto frameExtract(FrameExtractionRequestDto request) throws Exception {
+        return frameExtractionService.frameExtract(request);
+    }
+}

--- a/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractionService.java
+++ b/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractionService.java
@@ -25,16 +25,22 @@ public class FrameExtractionService {
 
         try {
             FrameGrab grab = FrameGrab.createFrameGrab(NIOUtils.readableChannel(request.originVideo));
+            int totalFrames = grab.getVideoTrack().getMeta().getTotalFrames();
+            int frameInterval = 10;
             Picture picture = null;
 
-            while ((picture = grab.getNativeFrame()) != null) {
-                response.frameSet.add(picture);
-                System.out.println(picture.getWidth() + " " + picture.getHeight());
-            }
+            System.out.println("totalFrames : " + totalFrames);
 
-            for (int i = 0; i < response.frameSet.size(); i += 2) {
-                BufferedImage bufferedImage = AWTUtil.toBufferedImage(response.frameSet.get(i));
-                ImageIO.write(bufferedImage, "png", new File("C:\\testFrame\\frame" + i + ".png"));
+            for (int i = 0; i < totalFrames; i += frameInterval) {
+                if ((picture = grab.seekToFramePrecise(i).getNativeFrame()) != null) {
+                    response.frameSet.add(picture);
+                    System.out.println(i + " " + picture.getWidth() + " " + picture.getHeight());
+
+                    BufferedImage bufferedImage = AWTUtil
+                            .toBufferedImage(response.frameSet.get((response.frameSet.size() - 1)));
+                    ImageIO.write(bufferedImage, "png",
+                            new File("C:\\testFrame\\frame" + (response.frameSet.size() - 1) + ".png"));
+                }
             }
 
             response.success = true;

--- a/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractionService.java
+++ b/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractionService.java
@@ -1,49 +1,42 @@
 package remora.remora.FrameExtraction;
 
-import java.io.File;
 import java.util.ArrayList;
 
-import java.awt.image.BufferedImage;
-
-import javax.imageio.ImageIO;
-
-import org.jcodec.api.FrameGrab;
-import org.jcodec.common.io.NIOUtils;
 import org.jcodec.common.model.Picture;
-import org.jcodec.scale.AWTUtil;
 import org.springframework.stereotype.Service;
 
 import remora.remora.FrameExtraction.dto.FrameExtractionRequestDto;
 import remora.remora.FrameExtraction.dto.FrameExtractionResponseDto;
+import remora.remora.FrameExtraction.thread.ExtractionThread;
 
 @Service
 public class FrameExtractionService {
     public FrameExtractionResponseDto frameExtract(FrameExtractionRequestDto request) {
         FrameExtractionResponseDto response = new FrameExtractionResponseDto();
+        int frameInterval = 10;
+        int threadSize = 8;
+        ExtractionThread[] extractionThread = new ExtractionThread[threadSize];
+        boolean isRunning = true;
+
         response.success = false;
         response.frameSet = new ArrayList<Picture>();
 
+        for (int i = 0; i < threadSize; i++) {
+            extractionThread[i] = new ExtractionThread(i, threadSize, frameInterval, response, request.originVideo);
+            extractionThread[i].start();
+        }
+
         try {
-            FrameGrab grab = FrameGrab.createFrameGrab(NIOUtils.readableChannel(request.originVideo));
-            int totalFrames = grab.getVideoTrack().getMeta().getTotalFrames();
-            int frameInterval = 10;
-            Picture picture = null;
+            while (isRunning) {
+                Thread.sleep(500);
+                isRunning = false;
 
-            System.out.println("totalFrames : " + totalFrames);
-
-            for (int i = 0; i < totalFrames; i += frameInterval) {
-                if ((picture = grab.seekToFramePrecise(i).getNativeFrame()) != null) {
-                    response.frameSet.add(picture);
-                    System.out.println(i + " " + picture.getWidth() + " " + picture.getHeight());
-
-                    BufferedImage bufferedImage = AWTUtil
-                            .toBufferedImage(response.frameSet.get((response.frameSet.size() - 1)));
-                    ImageIO.write(bufferedImage, "png",
-                            new File("C:\\testFrame\\frame" + (response.frameSet.size() - 1) + ".png"));
+                for (int i = 0; i < threadSize; i++) {
+                    if (extractionThread[i].isAlive()) {
+                        isRunning = true;
+                    }
                 }
             }
-
-            response.success = true;
         } catch (Exception e) {
             response.success = false;
             response.frameSet = null;

--- a/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractionService.java
+++ b/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractionService.java
@@ -1,8 +1,16 @@
 package remora.remora.FrameExtraction;
 
+import java.io.File;
+import java.util.ArrayList;
+
+import java.awt.image.BufferedImage;
+
+import javax.imageio.ImageIO;
+
 import org.jcodec.api.FrameGrab;
 import org.jcodec.common.io.NIOUtils;
 import org.jcodec.common.model.Picture;
+import org.jcodec.scale.AWTUtil;
 import org.springframework.stereotype.Service;
 
 import remora.remora.FrameExtraction.dto.FrameExtractionRequestDto;
@@ -12,14 +20,21 @@ import remora.remora.FrameExtraction.dto.FrameExtractionResponseDto;
 public class FrameExtractionService {
     public FrameExtractionResponseDto frameExtract(FrameExtractionRequestDto request) {
         FrameExtractionResponseDto response = new FrameExtractionResponseDto();
+        response.success = false;
+        response.frameSet = new ArrayList<Picture>();
 
         try {
             FrameGrab grab = FrameGrab.createFrameGrab(NIOUtils.readableChannel(request.originVideo));
             Picture picture = null;
 
             while ((picture = grab.getNativeFrame()) != null) {
-                System.out.println(picture.getWidth() + "x" + picture.getHeight() + " " + picture.getColor());
                 response.frameSet.add(picture);
+                System.out.println(picture.getWidth() + " " + picture.getHeight());
+            }
+
+            for (int i = 0; i < response.frameSet.size(); i += 2) {
+                BufferedImage bufferedImage = AWTUtil.toBufferedImage(response.frameSet.get(i));
+                ImageIO.write(bufferedImage, "png", new File("C:\\testFrame\\frame" + i + ".png"));
             }
 
             response.success = true;

--- a/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractionService.java
+++ b/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractionService.java
@@ -1,0 +1,34 @@
+package remora.remora.FrameExtraction;
+
+import org.jcodec.api.FrameGrab;
+import org.jcodec.common.io.NIOUtils;
+import org.jcodec.common.model.Picture;
+import org.springframework.stereotype.Service;
+
+import remora.remora.FrameExtraction.dto.FrameExtractionRequestDto;
+import remora.remora.FrameExtraction.dto.FrameExtractionResponseDto;
+
+@Service
+public class FrameExtractionService {
+    public FrameExtractionResponseDto frameExtract(FrameExtractionRequestDto request) {
+        FrameExtractionResponseDto response = new FrameExtractionResponseDto();
+
+        try {
+            FrameGrab grab = FrameGrab.createFrameGrab(NIOUtils.readableChannel(request.originVideo));
+            Picture picture = null;
+
+            while ((picture = grab.getNativeFrame()) != null) {
+                System.out.println(picture.getWidth() + "x" + picture.getHeight() + " " + picture.getColor());
+                response.frameSet.add(picture);
+            }
+
+            response.success = true;
+        } catch (Exception e) {
+            response.success = false;
+            response.frameSet = null;
+            e.printStackTrace();
+        }
+
+        return response;
+    }
+}

--- a/remora/src/main/java/remora/remora/FrameExtraction/dto/FrameExtractionRequestDto.java
+++ b/remora/src/main/java/remora/remora/FrameExtraction/dto/FrameExtractionRequestDto.java
@@ -1,0 +1,7 @@
+package remora.remora.FrameExtraction.dto;
+
+import java.io.File;
+
+public class FrameExtractionRequestDto {
+    public File originVideo;
+}

--- a/remora/src/main/java/remora/remora/FrameExtraction/dto/FrameExtractionResponseDto.java
+++ b/remora/src/main/java/remora/remora/FrameExtraction/dto/FrameExtractionResponseDto.java
@@ -1,0 +1,10 @@
+package remora.remora.FrameExtraction.dto;
+
+import java.util.ArrayList;
+
+import org.jcodec.common.model.Picture;
+
+public class FrameExtractionResponseDto {
+    public boolean success;
+    public ArrayList<Picture> frameSet;
+}

--- a/remora/src/main/java/remora/remora/FrameExtraction/thread/ExtractionThread.java
+++ b/remora/src/main/java/remora/remora/FrameExtraction/thread/ExtractionThread.java
@@ -1,0 +1,61 @@
+package remora.remora.FrameExtraction.thread;
+
+import java.io.File;
+
+import java.awt.image.BufferedImage;
+
+import javax.imageio.ImageIO;
+
+import org.jcodec.api.FrameGrab;
+import org.jcodec.common.io.NIOUtils;
+import org.jcodec.common.model.Picture;
+import org.jcodec.scale.AWTUtil;
+
+import remora.remora.FrameExtraction.dto.FrameExtractionResponseDto;
+
+public class ExtractionThread extends Thread {
+    private int threadNo;
+    private int threadSize;
+    private int frameInterval;
+    private FrameExtractionResponseDto response;
+    File originVideo;
+
+    public ExtractionThread(int threadNo, int threadSize, int frameInterval, FrameExtractionResponseDto response,
+            File originVideo) {
+        this.threadNo = threadNo;
+        this.threadSize = threadSize;
+        this.frameInterval = frameInterval;
+        this.response = response;
+        this.originVideo = originVideo;
+    }
+
+    public void run() {
+        try {
+            FrameGrab grab = FrameGrab.createFrameGrab(NIOUtils.readableChannel(originVideo));
+            Picture picture = null;
+            int totalFrames = grab.getVideoTrack().getMeta().getTotalFrames();
+
+            System.out.println("totalFrames : " + totalFrames);
+
+            for (int i = 0; i < totalFrames; i += frameInterval) {
+                if (i % threadSize == threadNo) {
+                    if ((picture = grab.seekToFramePrecise(i).getNativeFrame()) != null) {
+                        response.frameSet.add(picture);
+                        System.out.println(i + " " + picture.getWidth() + " " + picture.getHeight());
+
+                        BufferedImage bufferedImage = AWTUtil
+                                .toBufferedImage(response.frameSet.get((response.frameSet.size() - 1)));
+                        ImageIO.write(bufferedImage, "png",
+                                new File("C:\\testFrame\\frame" + (response.frameSet.size() - 1) + ".png"));
+                    }
+                }
+            }
+
+            response.success = true;
+        } catch (Exception e) {
+            response.success = false;
+            response.frameSet = null;
+            e.printStackTrace();
+        }
+    }
+}

--- a/remora/src/main/java/remora/remora/MainControl/MainController.java
+++ b/remora/src/main/java/remora/remora/MainControl/MainController.java
@@ -1,0 +1,26 @@
+package remora.remora.MainControl;
+
+import java.io.File;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import remora.remora.FrameExtraction.FrameExtractinController;
+import remora.remora.FrameExtraction.dto.FrameExtractionRequestDto;
+import remora.remora.FrameExtraction.dto.FrameExtractionResponseDto;
+
+@RestController
+public class MainController {
+    @GetMapping("/test/extraction")
+    public void testExtraction() {
+        FrameExtractinController frameExtractionController = new FrameExtractinController();
+        FrameExtractionRequestDto request = new FrameExtractionRequestDto();
+        FrameExtractionResponseDto response = null;
+
+        request.originVideo = new File("C:\\testVideo.mp4");
+        response = frameExtractionController.frameExtract(request);
+        if(response.success) {
+            System.out.println("Success frame extraction");
+        }
+    }
+}


### PR DESCRIPTION
[Task](https://www.notion.so/Server-b8ef8b2d27084b78bae61f2554067bc9)
JCodec을 사용한 영상 내 프레임을 추출하는 모듈입니다.

테스트한 값은 아래와 같습니다. (8스레드, 10프레임 단위로 추출)
```
frameInterval = 10;
threadSize = 8;
```

33초 길이의 영상, 100개의 frame 추출에 대해 대략 40초의 시간이 걸렸기 때문에 최적화 작업이 필요할 것으로 보입니다.
(+ VM으로 옮길 경우 CPU core가 1~2개의 환경으로 변하니 더 많은 시간이 소요될 것으로 예상됩니다.)
1080p 기준의 영상을 기준으로 했던 테스트라서 저화질 영상에 대한 테스트도 필요합니다.

(++ MainControl은 임시 테스트 용도이므로 MainControl을 개발하는 시기가 오면 기존 파일을 삭제하고 신규 개발하셔도 무방합니다.)