### PR TITLE
Feat : video upload api

### DIFF
--- a/remora/build.gradle
+++ b/remora/build.gradle
@@ -24,3 +24,8 @@ dependencies {
 test {
 	useJUnitPlatform()
 }
+
+javadoc {
+	source = sourceSets.main.java.srcDirs
+	options.encoding = 'UTF-8'
+}

--- a/remora/src/main/java/remora/remora/Api/ApiController.java
+++ b/remora/src/main/java/remora/remora/Api/ApiController.java
@@ -1,10 +1,15 @@
 package remora.remora.Api;
 
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import remora.remora.Api.ApiDTO.DeleteRequestDto;
 import remora.remora.Api.ApiDTO.SimpleResponseDto;
 import remora.remora.Api.ApiDTO.UploadRequestDto;
 import remora.remora.Api.ApiDTO.UploadResponseDto;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
  * Video 업로드 및 응답을 받기 위한 Controller
@@ -14,10 +19,15 @@ import remora.remora.Api.ApiDTO.UploadResponseDto;
 @RequestMapping("/remora")
 public class ApiController {
 
-    private ApiService apiService;
+    private ApiService apiService = new ApiService();
 
-    @GetMapping("/video")
-    UploadResponseDto uploadVideo(@RequestBody UploadRequestDto uploadReqDto){
+    @GetMapping(value = "/video", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    UploadResponseDto uploadVideo(@RequestParam("originVideo") List<MultipartFile> files,
+                                  @RequestParam("needTranslate") String needTranslate) throws IOException {
+
+        boolean trans = needTranslate.equals("true");
+
+        UploadRequestDto uploadReqDto = new UploadRequestDto(files, trans);
         return apiService.uploadVideo(uploadReqDto);
     }
 

--- a/remora/src/main/java/remora/remora/Api/ApiController.java
+++ b/remora/src/main/java/remora/remora/Api/ApiController.java
@@ -16,27 +16,27 @@ import java.util.List;
  */
 
 @RestController
-@RequestMapping("/remora")
+@RequestMapping("/")
 public class ApiController {
 
     private ApiService apiService = new ApiService();
 
-    @GetMapping(value = "/video", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @GetMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     UploadResponseDto uploadVideo(@RequestParam("originVideo") List<MultipartFile> files,
                                   @RequestParam("needTranslate") String needTranslate) throws IOException {
 
-        boolean trans = needTranslate.equals("true");
+        Boolean trans = needTranslate.equals("true");
 
         UploadRequestDto uploadReqDto = new UploadRequestDto(files, trans);
         return apiService.uploadVideo(uploadReqDto);
     }
 
-    @PutMapping("/video")
+    @PutMapping("/upload")
     SimpleResponseDto changeVideo(@RequestBody UploadRequestDto uploadReqDto){
         return apiService.changeVideo(uploadReqDto);
     }
 
-    @DeleteMapping("/video")
+    @DeleteMapping("/upload")
     SimpleResponseDto deleteVideo(@RequestBody DeleteRequestDto deleteReqDto){
         return apiService.deleteVideo(deleteReqDto);
     }

--- a/remora/src/main/java/remora/remora/Api/ApiController.java
+++ b/remora/src/main/java/remora/remora/Api/ApiController.java
@@ -6,9 +6,14 @@ import remora.remora.Api.ApiDTO.SimpleResponseDto;
 import remora.remora.Api.ApiDTO.UploadRequestDto;
 import remora.remora.Api.ApiDTO.UploadResponseDto;
 
+/**
+ * Video 업로드 및 응답을 받기 위한 Controller
+ */
+
 @RestController
 @RequestMapping("/remora")
 public class ApiController {
+
     private ApiService apiService;
 
     @GetMapping("/video")

--- a/remora/src/main/java/remora/remora/Api/ApiController.java
+++ b/remora/src/main/java/remora/remora/Api/ApiController.java
@@ -1,0 +1,28 @@
+package remora.remora.Api;
+
+import org.springframework.web.bind.annotation.*;
+import remora.remora.Api.ApiDTO.DeleteRequestDto;
+import remora.remora.Api.ApiDTO.SimpleResponseDto;
+import remora.remora.Api.ApiDTO.UploadRequestDto;
+import remora.remora.Api.ApiDTO.UploadResponseDto;
+
+@RestController
+@RequestMapping("/remora")
+public class ApiController {
+    private ApiService apiService;
+
+    @GetMapping("/video")
+    UploadResponseDto uploadVideo(@RequestBody UploadRequestDto uploadReqDto){
+        return apiService.uploadVideo(uploadReqDto);
+    }
+
+    @PutMapping("/video")
+    SimpleResponseDto changeVideo(@RequestBody UploadRequestDto uploadReqDto){
+        return apiService.changeVideo(uploadReqDto);
+    }
+
+    @DeleteMapping("/video")
+    SimpleResponseDto deleteVideo(@RequestBody DeleteRequestDto deleteReqDto){
+        return apiService.deleteVideo(deleteReqDto);
+    }
+}

--- a/remora/src/main/java/remora/remora/Api/ApiDTO/DeleteRequestDto.java
+++ b/remora/src/main/java/remora/remora/Api/ApiDTO/DeleteRequestDto.java
@@ -1,5 +1,5 @@
 package remora.remora.Api.ApiDTO;
 
 public class DeleteRequestDto {
-    boolean delete;
+    Boolean delete;
 }

--- a/remora/src/main/java/remora/remora/Api/ApiDTO/DeleteRequestDto.java
+++ b/remora/src/main/java/remora/remora/Api/ApiDTO/DeleteRequestDto.java
@@ -1,0 +1,5 @@
+package remora.remora.Api.ApiDTO;
+
+public class DeleteRequestDto {
+    boolean delete;
+}

--- a/remora/src/main/java/remora/remora/Api/ApiDTO/SimpleResponseDto.java
+++ b/remora/src/main/java/remora/remora/Api/ApiDTO/SimpleResponseDto.java
@@ -1,7 +1,7 @@
 package remora.remora.Api.ApiDTO;
 
 public class SimpleResponseDto {
-    boolean success;
+    Boolean success;
     String message;
     int code;
 }

--- a/remora/src/main/java/remora/remora/Api/ApiDTO/SimpleResponseDto.java
+++ b/remora/src/main/java/remora/remora/Api/ApiDTO/SimpleResponseDto.java
@@ -1,0 +1,7 @@
+package remora.remora.Api.ApiDTO;
+
+public class SimpleResponseDto {
+    boolean success;
+    String message;
+    int code;
+}

--- a/remora/src/main/java/remora/remora/Api/ApiDTO/UploadRequestDto.java
+++ b/remora/src/main/java/remora/remora/Api/ApiDTO/UploadRequestDto.java
@@ -18,7 +18,7 @@ public class UploadRequestDto {
     private Boolean needTranslate;
 
     public UploadRequestDto(List<MultipartFile> files, Boolean needTranslate) {
-        originVideo = files;
+        this.originVideo = files;
         this.needTranslate = needTranslate;
     }
 

--- a/remora/src/main/java/remora/remora/Api/ApiDTO/UploadRequestDto.java
+++ b/remora/src/main/java/remora/remora/Api/ApiDTO/UploadRequestDto.java
@@ -1,5 +1,9 @@
 package remora.remora.Api.ApiDTO;
 
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
 /**
  * 동영상을 업로드할 때 필요한 Object
  */
@@ -7,9 +11,22 @@ public class UploadRequestDto {
     /**
      * 원본 동영상 파일
      */
-    Byte originVideo;
+    private List<MultipartFile> originVideo;
     /**
-     * 번역 희망 여
+     * 번역 희망 여부
      */
-    Boolean needTranslate;
+    private Boolean needTranslate;
+
+    public UploadRequestDto(List<MultipartFile> files, Boolean needTranslate) {
+        originVideo = files;
+        this.needTranslate = needTranslate;
+    }
+
+    public Boolean getNeedTranslate(){
+        return this.needTranslate;
+    }
+
+    public List<MultipartFile> getVideoFiles(){
+        return this.originVideo;
+    }
 }

--- a/remora/src/main/java/remora/remora/Api/ApiDTO/UploadRequestDto.java
+++ b/remora/src/main/java/remora/remora/Api/ApiDTO/UploadRequestDto.java
@@ -1,0 +1,15 @@
+package remora.remora.Api.ApiDTO;
+
+/**
+ * 동영상을 업로드할 때 필요한 Object
+ */
+public class UploadRequestDto {
+    /**
+     * 원본 동영상 파일
+     */
+    Byte originVideo;
+    /**
+     * 번역 희망 여
+     */
+    Boolean needTranslate;
+}

--- a/remora/src/main/java/remora/remora/Api/ApiDTO/UploadResponseDto.java
+++ b/remora/src/main/java/remora/remora/Api/ApiDTO/UploadResponseDto.java
@@ -3,11 +3,11 @@ package remora.remora.Api.ApiDTO;
 import java.util.List;
 
 public class UploadResponseDto {
-    Boolean success;
-    String message;
-    int code;
-    List<String> originResultText;
-    List<String> translatedResultText;
-    List<String> keywords;
-    Boolean needTranslation;
+    public Boolean success;
+    public String message;
+    public int code;
+    public List<String> originResultText;
+    public List<String> translatedResultText;
+    public List<String> keywords;
+    public Boolean needTranslation;
 }

--- a/remora/src/main/java/remora/remora/Api/ApiDTO/UploadResponseDto.java
+++ b/remora/src/main/java/remora/remora/Api/ApiDTO/UploadResponseDto.java
@@ -1,0 +1,13 @@
+package remora.remora.Api.ApiDTO;
+
+import java.util.List;
+
+public class UploadResponseDto {
+    Boolean success;
+    String message;
+    int code;
+    List<String> originResultText;
+    List<String> translatedResultText;
+    List<String> keywords;
+    Boolean needTranslation;
+}

--- a/remora/src/main/java/remora/remora/Api/ApiService.java
+++ b/remora/src/main/java/remora/remora/Api/ApiService.java
@@ -1,0 +1,35 @@
+package remora.remora.Api;
+
+import org.springframework.stereotype.Service;
+import remora.remora.Api.ApiDTO.DeleteRequestDto;
+import remora.remora.Api.ApiDTO.SimpleResponseDto;
+import remora.remora.Api.ApiDTO.UploadRequestDto;
+import remora.remora.Api.ApiDTO.UploadResponseDto;
+
+@Service
+public class ApiService {
+    UploadResponseDto uploadVideo(UploadRequestDto uploadReqDto){
+        UploadResponseDto uploadResDto = new UploadResponseDto();
+        /*
+            To do
+         */
+        return uploadResDto;
+    }
+
+    SimpleResponseDto changeVideo(UploadRequestDto uploadReqDto){
+        SimpleResponseDto simpleResDto = new SimpleResponseDto();
+        /*
+            To do
+         */
+        return simpleResDto;
+    }
+
+    SimpleResponseDto deleteVideo(DeleteRequestDto deleteReqDto){
+        SimpleResponseDto simpleResDto = new SimpleResponseDto();
+        /*
+            To do
+         */
+        return simpleResDto;
+    }
+
+}

--- a/remora/src/main/java/remora/remora/Api/ApiService.java
+++ b/remora/src/main/java/remora/remora/Api/ApiService.java
@@ -1,18 +1,34 @@
 package remora.remora.Api;
 
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 import remora.remora.Api.ApiDTO.DeleteRequestDto;
 import remora.remora.Api.ApiDTO.SimpleResponseDto;
 import remora.remora.Api.ApiDTO.UploadRequestDto;
 import remora.remora.Api.ApiDTO.UploadResponseDto;
 
+import java.io.File;
+import java.io.IOException;
+
 @Service
 public class ApiService {
-    UploadResponseDto uploadVideo(UploadRequestDto uploadReqDto){
+    UploadResponseDto uploadVideo(UploadRequestDto uploadReqDto) throws IOException {
         UploadResponseDto uploadResDto = new UploadResponseDto();
+        int fileNumber = 1;
+
+        for(MultipartFile file : uploadReqDto.getVideoFiles()){
+            String fileType = file.getContentType();
+
+            if(fileType.contains("video") || fileType.contains("Video")){
+                File dest = new File(System.getenv("VIDEOPATH") + "/" + "req_video" + fileNumber++);
+                file.transferTo(dest);
+            }
+        }
+
         /*
-            To do
+            To Do : Set UploadResponseDto!
          */
+
         return uploadResDto;
     }
 

--- a/remora/src/main/java/remora/remora/Health/HealthController.java
+++ b/remora/src/main/java/remora/remora/Health/HealthController.java
@@ -5,8 +5,17 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 서버가 정상적으로 동작하는 지를 확인하기 위한 Healthy Controller
+ */
 @RestController
 public class HealthController {
+    /**
+     * @Author Seong Jin
+     * @Param
+     * @return Healthy
+     * @throws Exception
+     */
     @GetMapping("/health")
     @ResponseStatus(HttpStatus.OK)
     public String healthCheck() throws Exception {

--- a/remora/src/main/java/remora/remora/Health/HealthController.java
+++ b/remora/src/main/java/remora/remora/Health/HealthController.java
@@ -11,8 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class HealthController {
     /**
-     * @Author Seong Jin
-     * @Param
+     *
      * @return Healthy
      * @throws Exception
      */

--- a/remora/src/main/resources/application.properties
+++ b/remora/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-
+#Multipart
+spring.servlet.multipart.file-size-threshold=100MB
+spring.servlet.multipart.max-file-size=10GB
+spring.servlet.multipart.max-request-size=10GB


### PR DESCRIPTION
* 응용 프로그램 구동 시에 다음과 같이 환경변수 'VIDEOPATH' 에 업로드 될 동영상의 저장 경로를 지정해주어야 합니다.

![image](https://user-images.githubusercontent.com/61468564/143774114-9aad6c14-0817-4721-b731-86021a817811.png)

* API 요청 시에는 Body에 form-data 형식으로 다음과 같이 요청합니다.

needTranslate의 경우, 서버 내부적으로는 boolean으로 처리하지만, 요청 시에는 String으로 데이터가 전송되므로

서버 내부에서 'true' 일 시에 boolean형 true로 변환합니다. 따라서 요청 시 String형으로 "true" 로 요청하도록 합니다.

("true" 이 외의 데이터는 false로 처리 됩니다.)

![image](https://user-images.githubusercontent.com/61468564/143774182-85745cbe-7b9f-4a34-b9e7-5f364912eb91.png)

