### PR TITLE
Fix multithread, png sorting problem

### DIFF
--- a/remora/src/main/java/remora/remora/Common/PicturePair.java
+++ b/remora/src/main/java/remora/remora/Common/PicturePair.java
@@ -1,0 +1,21 @@
+package remora.remora.Common;
+
+import org.jcodec.common.model.Picture;
+
+public class PicturePair {
+    int pictureNo;
+    Picture picture;
+
+    public PicturePair(int pictureNo, Picture picture) {
+        this.pictureNo = pictureNo;
+        this.picture = picture;
+    }
+
+    public int first() {
+        return pictureNo;
+    }
+
+    public Picture second() {
+        return picture;
+    }
+}

--- a/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractinController.java
+++ b/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractinController.java
@@ -10,6 +10,11 @@ public class FrameExtractinController {
     FrameExtractionService frameExtractionService = new FrameExtractionService();
 
     public FrameExtractionResponseDto frameExtract(FrameExtractionRequestDto request) {
-        return frameExtractionService.frameExtract(request);
+        try {
+            return frameExtractionService.frameExtract(request);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 }

--- a/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractionService.java
+++ b/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractionService.java
@@ -2,16 +2,16 @@ package remora.remora.FrameExtraction;
 
 import java.util.ArrayList;
 
-import org.jcodec.common.model.Picture;
 import org.springframework.stereotype.Service;
 
+import remora.remora.Common.PicturePair;
 import remora.remora.FrameExtraction.dto.FrameExtractionRequestDto;
 import remora.remora.FrameExtraction.dto.FrameExtractionResponseDto;
 import remora.remora.FrameExtraction.thread.ExtractionThread;
 
 @Service
 public class FrameExtractionService {
-    public FrameExtractionResponseDto frameExtract(FrameExtractionRequestDto request) {
+    public FrameExtractionResponseDto frameExtract(FrameExtractionRequestDto request) throws InterruptedException {
         FrameExtractionResponseDto response = new FrameExtractionResponseDto();
         int frameInterval = 10;
         int threadSize = 8;
@@ -19,7 +19,7 @@ public class FrameExtractionService {
         boolean isRunning = true;
 
         response.success = false;
-        response.frameSet = new ArrayList<Picture>();
+        response.frameSet = new ArrayList<PicturePair>();
 
         for (int i = 0; i < threadSize; i++) {
             extractionThread[i] = new ExtractionThread(i, threadSize, frameInterval, response, request.originVideo);

--- a/remora/src/main/java/remora/remora/FrameExtraction/dto/FrameExtractionResponseDto.java
+++ b/remora/src/main/java/remora/remora/FrameExtraction/dto/FrameExtractionResponseDto.java
@@ -2,9 +2,9 @@ package remora.remora.FrameExtraction.dto;
 
 import java.util.ArrayList;
 
-import org.jcodec.common.model.Picture;
+import remora.remora.Common.PicturePair;
 
 public class FrameExtractionResponseDto {
     public boolean success;
-    public ArrayList<Picture> frameSet;
+    public ArrayList<PicturePair> frameSet;
 }

--- a/remora/src/main/java/remora/remora/MainControl/MainController.java
+++ b/remora/src/main/java/remora/remora/MainControl/MainController.java
@@ -17,7 +17,7 @@ public class MainController {
         FrameExtractionRequestDto request = new FrameExtractionRequestDto();
         FrameExtractionResponseDto response = null;
 
-        request.originVideo = new File("C:\\testVideo.mp4");
+        request.originVideo = new File("C:\\testVideo3.mp4");
         response = frameExtractionController.frameExtract(request);
         if(response.success) {
             System.out.println("Success frame extraction");


### PR DESCRIPTION
[Task](https://www.notion.so/Server-ddb8e4f55cbe4b1cbbd2acd86f4f2101)

이전 PR#1의 연장된 PR입니다.
1. 멀티스레드가 설정한 개수만큼 정상적으로 작동하지 않고 있던 문제를 수정하였습니다.
2. 이미지 png 파일이 생성될 때 sorting되지 않던 문제를 수정하였습니다.

(+영상의 화질을 480p로 낮추고 실험해본 결과 1080p 화질의 영상에서 프레임 추출할 때보다 비약적으로 빨라졌으며 OCR model에서도 480p의 글자 인식에 대해 문제가 없으므로 추후 고화질 영상이 input으로 들어온다면 저화질로 converting해주는 작업을 추가하면 좋을 것 같습니다.)