### PR TITLE
Feat : main controller

### DIFF
--- a/remora/src/main/java/remora/remora/Api/ApiController.java
+++ b/remora/src/main/java/remora/remora/Api/ApiController.java
@@ -16,28 +16,19 @@ import java.util.List;
  */
 
 @RestController
-@RequestMapping("/")
 public class ApiController {
 
     private ApiService apiService = new ApiService();
 
-    @GetMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    UploadResponseDto uploadVideo(@RequestParam("originVideo") List<MultipartFile> files,
-                                  @RequestParam("needTranslate") String needTranslate) throws IOException {
-
-        Boolean trans = needTranslate.equals("true");
-
-        UploadRequestDto uploadReqDto = new UploadRequestDto(files, trans);
+    public UploadResponseDto uploadVideo(UploadRequestDto uploadReqDto) throws IOException {
         return apiService.uploadVideo(uploadReqDto);
     }
 
-    @PutMapping("/upload")
-    SimpleResponseDto changeVideo(@RequestBody UploadRequestDto uploadReqDto){
+    public SimpleResponseDto changeVideo(UploadRequestDto uploadReqDto){
         return apiService.changeVideo(uploadReqDto);
     }
 
-    @DeleteMapping("/upload")
-    SimpleResponseDto deleteVideo(@RequestBody DeleteRequestDto deleteReqDto){
+    public SimpleResponseDto deleteVideo(DeleteRequestDto deleteReqDto){
         return apiService.deleteVideo(deleteReqDto);
     }
 }

--- a/remora/src/main/java/remora/remora/Api/ApiController.java
+++ b/remora/src/main/java/remora/remora/Api/ApiController.java
@@ -1,15 +1,12 @@
 package remora.remora.Api;
 
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import remora.remora.Api.dto.DeleteRequestDto;
 import remora.remora.Api.dto.SimpleResponseDto;
 import remora.remora.Api.dto.UploadRequestDto;
 import remora.remora.Api.dto.UploadResponseDto;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
  * Video 업로드 및 응답을 받기 위한 Controller

--- a/remora/src/main/java/remora/remora/Api/ApiController.java
+++ b/remora/src/main/java/remora/remora/Api/ApiController.java
@@ -3,10 +3,10 @@ package remora.remora.Api;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import remora.remora.Api.ApiDTO.DeleteRequestDto;
-import remora.remora.Api.ApiDTO.SimpleResponseDto;
-import remora.remora.Api.ApiDTO.UploadRequestDto;
-import remora.remora.Api.ApiDTO.UploadResponseDto;
+import remora.remora.Api.dto.DeleteRequestDto;
+import remora.remora.Api.dto.SimpleResponseDto;
+import remora.remora.Api.dto.UploadRequestDto;
+import remora.remora.Api.dto.UploadResponseDto;
 
 import java.io.IOException;
 import java.util.List;

--- a/remora/src/main/java/remora/remora/Api/ApiController.java
+++ b/remora/src/main/java/remora/remora/Api/ApiController.java
@@ -20,14 +20,30 @@ public class ApiController {
 
     private ApiService apiService = new ApiService();
 
+    /**
+     *
+     * @param uploadReqDto
+     * @return UploadResponseDto
+     * @throws IOException
+     */
     public UploadResponseDto uploadVideo(UploadRequestDto uploadReqDto) throws IOException {
         return apiService.uploadVideo(uploadReqDto);
     }
 
+    /**
+     *
+     * @param uploadReqDto
+     * @return SimpleResponseDto
+     */
     public SimpleResponseDto changeVideo(UploadRequestDto uploadReqDto){
         return apiService.changeVideo(uploadReqDto);
     }
 
+    /**
+     *
+     * @param deleteReqDto
+     * @return SimpleResponseDto
+     */
     public SimpleResponseDto deleteVideo(DeleteRequestDto deleteReqDto){
         return apiService.deleteVideo(deleteReqDto);
     }

--- a/remora/src/main/java/remora/remora/Api/ApiService.java
+++ b/remora/src/main/java/remora/remora/Api/ApiService.java
@@ -26,7 +26,7 @@ public class ApiService {
         }
 
         /*
-            To Do : Set UploadResponseDto!
+            To Do : Set UploadResponseDto
          */
 
         return uploadResDto;
@@ -35,7 +35,7 @@ public class ApiService {
     SimpleResponseDto changeVideo(UploadRequestDto uploadReqDto){
         SimpleResponseDto simpleResDto = new SimpleResponseDto();
         /*
-            To do
+            To do : Video 변경 작업 처리.
          */
         return simpleResDto;
     }
@@ -43,7 +43,7 @@ public class ApiService {
     SimpleResponseDto deleteVideo(DeleteRequestDto deleteReqDto){
         SimpleResponseDto simpleResDto = new SimpleResponseDto();
         /*
-            To do
+            To do : 요청 시에 업로드한 비디오를 삭제하는 작업 처리.
          */
         return simpleResDto;
     }

--- a/remora/src/main/java/remora/remora/Api/ApiService.java
+++ b/remora/src/main/java/remora/remora/Api/ApiService.java
@@ -2,10 +2,10 @@ package remora.remora.Api;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import remora.remora.Api.ApiDTO.DeleteRequestDto;
-import remora.remora.Api.ApiDTO.SimpleResponseDto;
-import remora.remora.Api.ApiDTO.UploadRequestDto;
-import remora.remora.Api.ApiDTO.UploadResponseDto;
+import remora.remora.Api.dto.DeleteRequestDto;
+import remora.remora.Api.dto.SimpleResponseDto;
+import remora.remora.Api.dto.UploadRequestDto;
+import remora.remora.Api.dto.UploadResponseDto;
 
 import java.io.File;
 import java.io.IOException;

--- a/remora/src/main/java/remora/remora/Api/dto/DeleteRequestDto.java
+++ b/remora/src/main/java/remora/remora/Api/dto/DeleteRequestDto.java
@@ -1,4 +1,4 @@
-package remora.remora.Api.ApiDTO;
+package remora.remora.Api.dto;
 
 public class DeleteRequestDto {
     Boolean delete;

--- a/remora/src/main/java/remora/remora/Api/dto/SimpleResponseDto.java
+++ b/remora/src/main/java/remora/remora/Api/dto/SimpleResponseDto.java
@@ -1,4 +1,4 @@
-package remora.remora.Api.ApiDTO;
+package remora.remora.Api.dto;
 
 public class SimpleResponseDto {
     Boolean success;

--- a/remora/src/main/java/remora/remora/Api/dto/UploadRequestDto.java
+++ b/remora/src/main/java/remora/remora/Api/dto/UploadRequestDto.java
@@ -1,4 +1,4 @@
-package remora.remora.Api.ApiDTO;
+package remora.remora.Api.dto;
 
 import org.springframework.web.multipart.MultipartFile;
 

--- a/remora/src/main/java/remora/remora/Api/dto/UploadResponseDto.java
+++ b/remora/src/main/java/remora/remora/Api/dto/UploadResponseDto.java
@@ -1,4 +1,4 @@
-package remora.remora.Api.ApiDTO;
+package remora.remora.Api.dto;
 
 import java.util.List;
 

--- a/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractionController.java
+++ b/remora/src/main/java/remora/remora/FrameExtraction/FrameExtractionController.java
@@ -6,7 +6,7 @@ import remora.remora.FrameExtraction.dto.FrameExtractionRequestDto;
 import remora.remora.FrameExtraction.dto.FrameExtractionResponseDto;
 
 @RestController
-public class FrameExtractinController {
+public class FrameExtractionController {
     FrameExtractionService frameExtractionService = new FrameExtractionService();
 
     public FrameExtractionResponseDto frameExtract(FrameExtractionRequestDto request) {

--- a/remora/src/main/java/remora/remora/MainControl/MainController.java
+++ b/remora/src/main/java/remora/remora/MainControl/MainController.java
@@ -1,10 +1,18 @@
 package remora.remora.MainControl;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.List;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
 
+import org.springframework.web.multipart.MultipartFile;
+import remora.remora.Api.ApiController;
+import remora.remora.Api.dto.DeleteRequestDto;
+import remora.remora.Api.dto.SimpleResponseDto;
+import remora.remora.Api.dto.UploadRequestDto;
+import remora.remora.Api.dto.UploadResponseDto;
 import remora.remora.FrameExtraction.FrameExtractionController;
 import remora.remora.FrameExtraction.dto.FrameExtractionRequestDto;
 import remora.remora.FrameExtraction.dto.FrameExtractionResponseDto;
@@ -15,9 +23,33 @@ import remora.remora.Translation.dto.TranslationResponseDto;
 
 @RestController
 public class MainController {
+    FrameExtractionController frameExtractionController = new FrameExtractionController();
+    TranslationController translationController = new TranslationController();
+    ApiController apiController = new ApiController();
+
+    @GetMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    UploadResponseDto uploadVideo(@RequestParam("originVideo") List<MultipartFile> files,
+                                  @RequestParam("needTranslate") String needTranslate) throws IOException {
+
+        Boolean trans = needTranslate.equals("true");
+        UploadRequestDto request = new UploadRequestDto(files, trans);
+
+        return apiController.uploadVideo(request);
+    }
+
+    @PutMapping("/upload")
+    SimpleResponseDto changeVideo(@RequestBody UploadRequestDto uploadReqDto){
+        return apiController.changeVideo(uploadReqDto);
+    }
+
+    @DeleteMapping("/upload")
+    SimpleResponseDto deleteVideo(@RequestBody DeleteRequestDto deleteReqDto){
+        return apiController.deleteVideo(deleteReqDto);
+    }
+
     @GetMapping("/test/extraction")
     public void testExtraction() {
-        FrameExtractionController frameExtractionController = new FrameExtractionController();
+        //FrameExtractionController frameExtractionController = new FrameExtractionController();
         FrameExtractionRequestDto request = new FrameExtractionRequestDto();
         FrameExtractionResponseDto response = null;
 
@@ -30,7 +62,7 @@ public class MainController {
 
     @GetMapping("/test/translate")
     public void testTranslate() {
-        TranslationController translationController = new TranslationController();
+        //TranslationController translationController = new TranslationController();
         TranslationRequestDto request = new TranslationRequestDto();
         TranslationResponseDto response = new TranslationResponseDto();
 

--- a/remora/src/main/java/remora/remora/MainControl/MainController.java
+++ b/remora/src/main/java/remora/remora/MainControl/MainController.java
@@ -26,7 +26,13 @@ public class MainController {
     FrameExtractionController frameExtractionController = new FrameExtractionController();
     TranslationController translationController = new TranslationController();
     ApiController apiController = new ApiController();
-
+    
+    /*
+        To do : 다음과 같은 OcrController 객체가 생성 되어야 함.
+         
+        OcrController ocrController = new OcrController();
+     */
+    
     @GetMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     UploadResponseDto uploadVideo(@RequestParam("originVideo") List<MultipartFile> files,
                                   @RequestParam("needTranslate") String needTranslate) throws IOException {
@@ -46,10 +52,12 @@ public class MainController {
     SimpleResponseDto deleteVideo(@RequestBody DeleteRequestDto deleteReqDto){
         return apiController.deleteVideo(deleteReqDto);
     }
-
+    
+    /*
+        To do : 프레임 추출 모듈을 호출할 때 참고할 코드이며, File path는 환경변수로 관리할 예정임.
+     */
     @GetMapping("/test/extraction")
     public void testExtraction() {
-        //FrameExtractionController frameExtractionController = new FrameExtractionController();
         FrameExtractionRequestDto request = new FrameExtractionRequestDto();
         FrameExtractionResponseDto response = null;
 
@@ -59,10 +67,12 @@ public class MainController {
             System.out.println("Success frame extraction");
         }
     }
-
+    
+    /*
+        To do : 번역 모듈을 호출할 때 참고할 코드임.
+     */
     @GetMapping("/test/translate")
     public void testTranslate() {
-        //TranslationController translationController = new TranslationController();
         TranslationRequestDto request = new TranslationRequestDto();
         TranslationResponseDto response = new TranslationResponseDto();
 

--- a/remora/src/main/java/remora/remora/MainControl/MainController.java
+++ b/remora/src/main/java/remora/remora/MainControl/MainController.java
@@ -5,7 +5,7 @@ import java.io.File;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import remora.remora.FrameExtraction.FrameExtractinController;
+import remora.remora.FrameExtraction.FrameExtractionController;
 import remora.remora.FrameExtraction.dto.FrameExtractionRequestDto;
 import remora.remora.FrameExtraction.dto.FrameExtractionResponseDto;
 
@@ -17,7 +17,7 @@ import remora.remora.Translation.dto.TranslationResponseDto;
 public class MainController {
     @GetMapping("/test/extraction")
     public void testExtraction() {
-        FrameExtractinController frameExtractionController = new FrameExtractinController();
+        FrameExtractionController frameExtractionController = new FrameExtractionController();
         FrameExtractionRequestDto request = new FrameExtractionRequestDto();
         FrameExtractionResponseDto response = null;
 

--- a/remora/src/main/java/remora/remora/MainControl/MainController.java
+++ b/remora/src/main/java/remora/remora/MainControl/MainController.java
@@ -5,7 +5,13 @@ import java.io.IOException;
 import java.util.List;
 
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestBody;
+
 
 import org.springframework.web.multipart.MultipartFile;
 import remora.remora.Api.ApiController;


### PR DESCRIPTION
MainController에서 API 호출을 처리하기 위해, 기존 API Controller의 메소드들에 작성되어 있던 Mapping 방식이나 Request Param의 내용을 모두 Main Controller의 API 호출 메소드에 옮겨 적었습니다. 

또, 프레임 추출, 번역, API Controller를 메소드 호출 시마다 생성하는 것이 아니라 Main Controller가 생성될 때 클래스 내부적으로 한번만 생성 되도록 하였습니다. OcrController도 똑같이 적용할 계획입니다. 

추가로 작은 오탈자와 API 모듈의 Dto 디렉터리의 이름을 수정하였습니다. 구체적인 수정 사항은 다음과 같습니다.

Frame**Extractin**Controller -> Frame**Extraction**Controller

remora/Api/**ApiDto** -> remora/Api/**dto**