### PR TITLE
feat: uploadResponse에 더미 데이터 주입

### DIFF
--- a/remora/src/main/java/remora/remora/Api/ApiService.java
+++ b/remora/src/main/java/remora/remora/Api/ApiService.java
@@ -10,6 +10,7 @@ import remora.remora.Api.dto.UploadResponseDto;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 
 @Service
 public class ApiService {
@@ -29,6 +30,15 @@ public class ApiService {
 
         uploadResDto.code = fileNumber++;
         uploadResDto.needTranslation = uploadReqDto.getNeedTranslate();
+
+        /*
+             dummy data insert
+         */
+        uploadResDto.keywords = Arrays.asList("Hello", "World");
+        uploadResDto.originResultText = Arrays.asList("Good", "Day");
+        uploadResDto.translatedResultText = Arrays.asList("Remora", "is Good");
+        uploadResDto.message = "Remora Project";
+        uploadResDto.success = true;
 
         return uploadResDto;
     }

--- a/remora/src/main/java/remora/remora/MainControl/MainController.java
+++ b/remora/src/main/java/remora/remora/MainControl/MainController.java
@@ -38,8 +38,7 @@ public class MainController {
      */
     @ApiOperation(value = "Main Controller Swagger", produces = "multipart/form-data")
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    ArrayList<UploadResponseDto> uploadVideo(@Parameter(description = "추출할 비디오", required = true, content = @Content(mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE))
-                                             @RequestPart("originVideo") List<MultipartFile> files,
+    ArrayList<UploadResponseDto> uploadVideo(@RequestParam("originVideo") List<MultipartFile> files,
                                              @Parameter(description = "번역 희망 여부(true or false)", required = true)
                                              @RequestParam("needTranslate") List<String> needTranslate) throws IOException {
         Dotenv dotenv = Dotenv.configure().load();


### PR DESCRIPTION
클라이언트 업로드 테스트를 위해 uploadResponse에 더미 데이터를 주입하였습니다.

출력 결과는 다음과 같이 될 것입니다.

[
    {
        "success": true,
        "message": "Remora Project",
        "code": 1,
        "originResultText": [
            "Good",
            "Day"
        ],
        "translatedResultText": [
            "Remora",
            "is Good"
        ],
        "keywords": [
            "Hello",
            "World"
        ],
        "needTranslation": true
    }
]