### PR TITLE
Test/ocr

### DIFF
--- a/remora/src/main/java/remora/remora/Common/Cli.java
+++ b/remora/src/main/java/remora/remora/Common/Cli.java
@@ -8,10 +8,7 @@ public class Cli {
             Process process = Runtime.getRuntime().exec(String.format(command, args));
             process.waitFor();
             return true;
-        } catch (IOException e) {
-            e.printStackTrace();
-            return false;
-        } catch (InterruptedException e) {
+        } catch (Exception e) {
             e.printStackTrace();
             return false;
         }

--- a/remora/src/main/java/remora/remora/Ocr/OcrService.java
+++ b/remora/src/main/java/remora/remora/Ocr/OcrService.java
@@ -35,7 +35,13 @@ public class OcrService {
             }
             reader.close();
         } else {
+            System.out.println("Run OCR module error");
             throw new Exception("Run OCR module error");
+        }
+
+        if (ret.length() == 0) {
+            System.out.println("There is no text in video");
+            throw new Exception("There is no text in video");
         }
 
         return ret.toString();

--- a/remora/src/test/java/remora/remora/Ocr/OcrTest.java
+++ b/remora/src/test/java/remora/remora/Ocr/OcrTest.java
@@ -1,0 +1,73 @@
+package remora.remora.Ocr;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SpringBootTest
+public class OcrTest {
+    @Value("${ocr-result-path}")
+    String ocrResultPath;
+
+    @Autowired
+    OcrService ocrService;
+
+    @Test
+    public void ocr() {
+        ArrayList<Integer> frameSet = new ArrayList<>();
+        String videoCode = "1";
+
+        frameSet.add(0);
+        frameSet.add(150);
+        frameSet.add(300);
+        frameSet.add(450);
+        frameSet.add(600);
+        frameSet.add(750);
+        frameSet.add(900);
+        frameSet.add(1050);
+        frameSet.add(1200);
+        frameSet.add(1350);
+        frameSet.add(1500);
+        frameSet.add(1650);
+        frameSet.add(1800);
+        frameSet.add(1950);
+        frameSet.add(2100);
+        frameSet.add(2250);
+        frameSet.add(2400);
+        frameSet.add(2550);
+        frameSet.add(2700);
+        frameSet.add(2850);
+        frameSet.add(3000);
+        frameSet.add(3150);
+        frameSet.add(3300);
+        frameSet.add(3450);
+        frameSet.add(3600);
+        frameSet.add(3750);
+
+        try {
+            StringBuilder expectedStr = new StringBuilder();
+            BufferedReader reader = new BufferedReader(new FileReader(ocrResultPath));
+            String str;
+
+            while ((str = reader.readLine()) != null) {
+                expectedStr.append(str + "\n");
+            }
+            reader.close();
+
+            String result = ocrService.detection(frameSet, videoCode);
+
+            assertThat(result).isEqualTo(expectedStr.toString());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+}

--- a/remora/src/test/java/remora/remora/Ocr/OcrTest.java
+++ b/remora/src/test/java/remora/remora/Ocr/OcrTest.java
@@ -53,6 +53,8 @@ public class OcrTest {
         frameSet.add(3750);
 
         try {
+            String result = ocrService.detection(frameSet, videoCode);
+
             StringBuilder expectedStr = new StringBuilder();
             BufferedReader reader = new BufferedReader(new FileReader(ocrResultPath));
             String str;
@@ -61,8 +63,6 @@ public class OcrTest {
                 expectedStr.append(str + "\n");
             }
             reader.close();
-
-            String result = ocrService.detection(frameSet, videoCode);
 
             assertThat(result).isEqualTo(expectedStr.toString());
         } catch (Exception e) {


### PR DESCRIPTION
1. `Ocr` 모듈에 대한 테스트 코드입니다.
2. `resources/`에 존재하는 `ocrMockModule.exe`을 실행합니다.
3. 영상에 글자가 없는 상황을 가정하여 빈파일을 읽는 경우는 `resources/testVideo/testFrames/.gitkeep`을 읽도록 개발했습니다.