### PR TITLE
Refactoring/translation

### DIFF
--- a/remora/src/main/java/remora/remora/Adapter/Papago.java
+++ b/remora/src/main/java/remora/remora/Adapter/Papago.java
@@ -1,6 +1,7 @@
 package remora.remora.Adapter;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
@@ -16,6 +17,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.io.InputStream;
 
+@Component
 public class Papago {
     private static String clientId;
     private static String clientSecret;
@@ -35,7 +37,7 @@ public class Papago {
 
         String responseBody = post(apiURL, requestHeaders, text);
 
-        System.out.println(responseBody);
+        System.out.println("responseBody = " + responseBody);
         return responseBody;
     }
 
@@ -96,12 +98,12 @@ public class Papago {
     }
 
     @Value("${papago.id}")
-    public static void setClientId(String clientId) {
+    public void setClientId(String clientId) {
         Papago.clientId = clientId;
     }
 
     @Value("${papago.pw}")
-    public static void setClientSecret(String clientSecret) {
+    public void setClientSecret(String clientSecret) {
         Papago.clientSecret = clientSecret;
     }
 }

--- a/remora/src/main/java/remora/remora/Adapter/Papago.java
+++ b/remora/src/main/java/remora/remora/Adapter/Papago.java
@@ -6,12 +6,12 @@ import org.springframework.stereotype.Component;
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import java.util.HashMap;
@@ -25,11 +25,7 @@ public class Papago {
     public static String call(String originText) {
         String apiURL = "https://openapi.naver.com/v1/papago/n2mt";
         String text;
-        try {
-            text = URLEncoder.encode(originText, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException("Encoding fail", e);
-        }
+        text = URLEncoder.encode(originText, StandardCharsets.UTF_8);
 
         Map<String, String> requestHeaders = new HashMap<>();
         requestHeaders.put("X-Naver-Client-Id", clientId);

--- a/remora/src/main/java/remora/remora/Adapter/Papago.java
+++ b/remora/src/main/java/remora/remora/Adapter/Papago.java
@@ -22,7 +22,7 @@ public class Papago {
     private static String clientId;
     private static String clientSecret;
 
-    public static String call(String originText) {
+    public static String translate(String originText) {
         String apiURL = "https://openapi.naver.com/v1/papago/n2mt";
         String text;
         text = URLEncoder.encode(originText, StandardCharsets.UTF_8);

--- a/remora/src/main/java/remora/remora/Exception/RequestDataLengthDifferentException.java
+++ b/remora/src/main/java/remora/remora/Exception/RequestDataLengthDifferentException.java
@@ -1,0 +1,11 @@
+package remora.remora.Exception;
+
+public class RequestDataLengthDifferentException extends RuntimeException {
+    public RequestDataLengthDifferentException() {
+        super("Request Data length is different");
+    }
+
+    public RequestDataLengthDifferentException(String s) {
+        super(s);
+    }
+}

--- a/remora/src/main/java/remora/remora/Translation/Adapter/Papago.java
+++ b/remora/src/main/java/remora/remora/Translation/Adapter/Papago.java
@@ -1,4 +1,4 @@
-package remora.remora.Adapter;
+package remora.remora.Translation.Adapter;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;

--- a/remora/src/main/java/remora/remora/Translation/Adapter/Papago.java
+++ b/remora/src/main/java/remora/remora/Translation/Adapter/Papago.java
@@ -18,11 +18,13 @@ import java.util.HashMap;
 import java.io.InputStream;
 
 @Component
-public class Papago {
-    private static String clientId;
-    private static String clientSecret;
+public class Papago implements TranslationAdapter {
+    @Value("${papago.id}")
+    private String clientId;
+    @Value("${papago.pw}")
+    private String clientSecret;
 
-    public static String translate(String originText) {
+    public String translate(String originText) {
         String apiURL = "https://openapi.naver.com/v1/papago/n2mt";
         String text;
         text = URLEncoder.encode(originText, StandardCharsets.UTF_8);
@@ -37,7 +39,7 @@ public class Papago {
         return responseBody;
     }
 
-    private static String post(String apiUrl, Map<String, String> requestHeaders, String text) {
+    private String post(String apiUrl, Map<String, String> requestHeaders, String text) {
         HttpURLConnection con = connect(apiUrl);
         String postParams = "source=en&target=ko&text=" + text;
         try {
@@ -65,7 +67,7 @@ public class Papago {
         }
     }
 
-    private static HttpURLConnection connect(String apiUrl) {
+    private HttpURLConnection connect(String apiUrl) {
         try {
             URL url = new URL(apiUrl);
             return (HttpURLConnection) url.openConnection();
@@ -76,7 +78,7 @@ public class Papago {
         }
     }
 
-    private static String readBody(InputStream body) {
+    private String readBody(InputStream body) {
         InputStreamReader streamReader = new InputStreamReader(body);
 
         try (BufferedReader lineReader = new BufferedReader(streamReader)) {
@@ -91,15 +93,5 @@ public class Papago {
         } catch (IOException e) {
             throw new RuntimeException("API 응답을 읽는데 실패했습니다.", e);
         }
-    }
-
-    @Value("${papago.id}")
-    public void setClientId(String clientId) {
-        Papago.clientId = clientId;
-    }
-
-    @Value("${papago.pw}")
-    public void setClientSecret(String clientSecret) {
-        Papago.clientSecret = clientSecret;
     }
 }

--- a/remora/src/main/java/remora/remora/Translation/Adapter/TranslationAdapter.java
+++ b/remora/src/main/java/remora/remora/Translation/Adapter/TranslationAdapter.java
@@ -1,0 +1,5 @@
+package remora.remora.Translation.Adapter;
+
+public interface TranslationAdapter {
+    String translate(String text);
+}

--- a/remora/src/main/java/remora/remora/Translation/TranslationController.java
+++ b/remora/src/main/java/remora/remora/Translation/TranslationController.java
@@ -1,20 +1,47 @@
 package remora.remora.Translation;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import remora.remora.Translation.dto.TranslationRequestDto;
 import remora.remora.Translation.dto.TranslationResponseDto;
 
+import javax.validation.Valid;
+
 @RestController
 public class TranslationController {
-    TranslationService translationService = new TranslationService();
+    private final TranslationService translationService;
 
-    public TranslationResponseDto translate(TranslationRequestDto request) {
+    @Autowired
+    public TranslationController(TranslationService translationService) {
+        this.translationService = translationService;
+    }
+
+    @GetMapping("/text/translated")
+    @ResponseBody
+    public TranslationResponseDto translate(@RequestBody @Valid TranslationRequestDto request) {
+        TranslationResponseDto response = new TranslationResponseDto();
+
         try {
-            return translationService.translate(request);
+            for (int i = 0; i < request.text.size(); i++) {
+                response.translatedText.add(translationService.translate(request.text.get(i), request.needTranslation.get(i)));
+                response.text.add(request.text.get(i));
+            }
+
+            response.success = true;
+            response.message = "Success";
         } catch (Exception e) {
             e.printStackTrace();
-            return null;
+
+            response.success = false;
+            response.message = e.toString();
+            response.text = null;
+            response.translatedText = null;
         }
+
+        return response;
     }
 }

--- a/remora/src/main/java/remora/remora/Translation/TranslationController.java
+++ b/remora/src/main/java/remora/remora/Translation/TranslationController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import remora.remora.Exception.RequestDataLengthDifferentException;
 import remora.remora.Translation.dto.TranslationRequestDto;
 import remora.remora.Translation.dto.TranslationResponseDto;
 
@@ -26,6 +27,10 @@ public class TranslationController {
         TranslationResponseDto response = new TranslationResponseDto();
 
         try {
+            if (request.text.size() != request.needTranslation.size()) {
+                throw new RequestDataLengthDifferentException("text length : " + request.text.size() + ", needTranslation length : " + request.needTranslation.size());
+            }
+
             for (int i = 0; i < request.text.size(); i++) {
                 response.translatedText.add(translationService.translate(request.text.get(i), request.needTranslation.get(i)));
                 response.text.add(request.text.get(i));

--- a/remora/src/main/java/remora/remora/Translation/TranslationService.java
+++ b/remora/src/main/java/remora/remora/Translation/TranslationService.java
@@ -2,7 +2,7 @@ package remora.remora.Translation;
 
 import org.springframework.stereotype.Service;
 
-import remora.remora.Adapter.Papago;
+import remora.remora.Translation.Adapter.Papago;
 
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;

--- a/remora/src/main/java/remora/remora/Translation/TranslationService.java
+++ b/remora/src/main/java/remora/remora/Translation/TranslationService.java
@@ -1,20 +1,27 @@
 package remora.remora.Translation;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import remora.remora.Translation.Adapter.Papago;
 
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import remora.remora.Translation.Adapter.TranslationAdapter;
 
 @Service
 public class TranslationService {
+    private final TranslationAdapter translationModel;
+
+    @Autowired
+    public TranslationService(TranslationAdapter translationModel) {
+        this.translationModel = translationModel;
+    }
+
     public String translate(String text, Boolean needTranslation) throws Exception {
         if (!needTranslation) {
             return text;
         }
 
-        String responseBodyStr = Papago.translate(text);
+        String responseBodyStr = translationModel.translate(text);
         JSONParser parser = new JSONParser();
         Object obj = parser.parse(responseBodyStr);
         JSONObject jsonObj = (JSONObject) obj;

--- a/remora/src/main/java/remora/remora/Translation/TranslationService.java
+++ b/remora/src/main/java/remora/remora/Translation/TranslationService.java
@@ -11,7 +11,7 @@ import org.json.simple.parser.JSONParser;
 public class TranslationService {
     public String translate(String text, Boolean needTranslation) throws Exception {
         if (!needTranslation) {
-            return null;
+            return text;
         }
 
         String responseBodyStr = Papago.call(text);

--- a/remora/src/main/java/remora/remora/Translation/TranslationService.java
+++ b/remora/src/main/java/remora/remora/Translation/TranslationService.java
@@ -3,49 +3,21 @@ package remora.remora.Translation;
 import org.springframework.stereotype.Service;
 
 import remora.remora.Adapter.Papago;
-import remora.remora.Translation.dto.TranslationRequestDto;
-import remora.remora.Translation.dto.TranslationResponseDto;
 
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 
 @Service
 public class TranslationService {
-    public TranslationResponseDto translate(TranslationRequestDto request) throws Exception {
-        TranslationResponseDto response = new TranslationResponseDto();
-        response.originText = request.originText;
-
-        if(!request.needTranslation){
-            response.success = false;
-            response.translatedText = " ";
-            return response;
+    public String translate(String text, Boolean needTranslation) throws Exception {
+        if (!needTranslation) {
+            return null;
         }
 
-        response.success = false;
-        response.translatedText = " ";
-
-        if (!this.checkSupportedLanguage(request.language)) {
-            throw new Exception("Cannot translate language " + request.language);
-        }
-
-        String responseBodyStr = Papago.call(request.originText);
+        String responseBodyStr = Papago.call(text);
         JSONParser parser = new JSONParser();
         Object obj = parser.parse(responseBodyStr);
         JSONObject jsonObj = (JSONObject) obj;
-        // TODO find better solution for nested json
-        response.translatedText = (String) ((JSONObject) ((JSONObject) jsonObj.get("message")).get("result"))
-                .get("translatedText");
-        response.success = true;
-
-        return response;
-    }
-
-    private Boolean checkSupportedLanguage(String language) {
-        // TODO only support en -> ko
-        if (language.equals("en")) {
-            return true;
-        } else {
-            return false;
-        }
+        return (String) ((JSONObject) ((JSONObject) jsonObj.get("message")).get("result")).get("translatedText");
     }
 }

--- a/remora/src/main/java/remora/remora/Translation/TranslationService.java
+++ b/remora/src/main/java/remora/remora/Translation/TranslationService.java
@@ -14,7 +14,7 @@ public class TranslationService {
             return text;
         }
 
-        String responseBodyStr = Papago.call(text);
+        String responseBodyStr = Papago.translate(text);
         JSONParser parser = new JSONParser();
         Object obj = parser.parse(responseBodyStr);
         JSONObject jsonObj = (JSONObject) obj;

--- a/remora/src/main/java/remora/remora/Translation/dto/TranslationRequestDto.java
+++ b/remora/src/main/java/remora/remora/Translation/dto/TranslationRequestDto.java
@@ -1,13 +1,20 @@
 package remora.remora.Translation.dto;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+
 public class TranslationRequestDto {
-    public String originText;
-    public String language;
-    public Boolean needTranslation;
-    
-    public TranslationRequestDto(StringBuffer originText, String language, Boolean needTranslation){
-        this.originText = originText.toString();
-        this.language = language;
-        this.needTranslation = needTranslation;
+    @NotEmpty
+    @NotNull
+    public List<String> text;
+    @NotEmpty
+    @NotNull
+    public List<Boolean> needTranslation;
+
+    public TranslationRequestDto() {
+        this.text = new ArrayList<>();
+        this.needTranslation = new ArrayList<>();
     }
 }

--- a/remora/src/main/java/remora/remora/Translation/dto/TranslationResponseDto.java
+++ b/remora/src/main/java/remora/remora/Translation/dto/TranslationResponseDto.java
@@ -1,7 +1,18 @@
 package remora.remora.Translation.dto;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class TranslationResponseDto {
-    public Boolean success;
-    public String originText;
-    public String translatedText;
+    public boolean success;
+    public String message;
+    public List<String> text;
+    public List<String> translatedText;
+
+    public TranslationResponseDto() {
+        this.success = false;
+        this.message = null;
+        this.text = new ArrayList<>();
+        this.translatedText = new ArrayList<>();
+    }
 }


### PR DESCRIPTION
번역모듈 리팩토링 PR 입니다.

`RequestDataLengthDifferentException`이 추가되었습니다. request body에서 list의 길이가 같아야만 하는 데이터를 체크하기 위해 추가되었습니다. `Ocr`모듈에도 적용이 필요합니다. 해당 부분은 다른 PR을 통해 공유드리겠습니다.

현재 번역을 위해 파파고 API를 사용하고 있습니다. 파파고 API를 호출할 때 static method를 통해 직접 호출하던 부분을 interface로 처리하여 다른 번역 API로 교체하거나 유지보수할 수 있도록 변경했습니다.

번역모듈과 관련된 테스트코드는 다른 PR을 통해 공유드리겠습니다.